### PR TITLE
fix: published image name to wordpress from docker-wordpress

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,10 +4,11 @@
 # Order is important: the last matching pattern has the highest precedence
 
 # These owners will be the default owners for everything
-*                                        @gridverse-in/admins
-
-*                                        @gridverse-in/engineering
+*                                        @gridverse-in/admins  @gridverse-in/engineering
 .github/CODEOWNERS
 .github/workflows/*.yml
+
+.github/CODEOWNERS                       @gridverse-in/admins
+.github/workflows/*.yml                  @gridverse-in/admins
 
 *.md                                     @gridverse-in/docs

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -6,6 +6,10 @@ on:
       - opened
       - edited
       - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
 
 jobs:
   lint_pr:
@@ -44,13 +48,13 @@ jobs:
             Our pull requests titles follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
 
             Details:
-            
+
             ```
             ${{ steps.lint_pr_title.outputs.error_message }}
             ```
 
       - uses: marocchino/sticky-pull-request-comment@v2.3.1
         if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        with:   
+        with:
           header: pr-title-lint-error
           delete: true

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -28,7 +28,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/${{ github.repository }}
+            ghcr.io/gridverse-in/wordpress
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Changed image name from docker-wordpress to wordpress

## Description
right now docker image is published as ghcr.io/gridverse-in/docker-wordpress expected name to be ghcr.io/gridverse-in/wordpress


## Related Issue
N.A.

## Motivation and Context
Naming conventions

## How Has This Been Tested?
N.A.

## Screenshots (if appropriate):