### PR TITLE
fix: missing cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 ARG WORDPRESS_VERSION=6.5.5
 ARG PHP_VERSION=8.3
-ARG WP_CLI_VERSION=2.10.0
 
 
 # Use the official WordPress image as the base
 FROM wordpress:${WORDPRESS_VERSION}-php${PHP_VERSION}-apache
 
+ARG WP_CLI_VERSION=2.10.0
+
 # Install wp-cli
-RUN curl -o /usr/local/bin/wp -O "https://github.com/wp-cli/wp-cli/releases/download/v${WORDPRESS_CLI_VERSION}/wp-cli-${WORDPRESS_CLI_VERSION}.phar" \
+RUN curl -o /usr/local/bin/wp -OfL "https://github.com/wp-cli/wp-cli/releases/download/v${WP_CLI_VERSION}/wp-cli-${WP_CLI_VERSION}.phar" \
     && chmod +x /usr/local/bin/wp


### PR DESCRIPTION
Fix missing wp-cli

## Description


## Related Issue
N.A.

## Motivation and Context
N.A.

## How Has This Been Tested?
built image locally and verified

## Screenshots (if appropriate):